### PR TITLE
Staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.0-rc.1](https://github.com/ethiack/job-manager/compare/1.0.2...1.1.0-rc.1) (2025-04-08)
+
+
+### 🚀 Features
+
+* add Multi-Event and Beacon logic ([#6](https://github.com/ethiack/job-manager/issues/6)) ([39705c3](https://github.com/ethiack/job-manager/commit/39705c3dc1d42523c28c67bd8d4090e34544f053))
+
 ## [1.0.2](https://github.com/ethiack/job-manager/compare/1.0.1...1.0.2) (2024-05-29)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "Python package for managing jobs using Ethiack's Public API"
 dynamic = ["readme"]
 license = {file = "LICENSE"}
-version = "1.0.2"
+version = "1.1.0rc1"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/src/ethiack_job_manager/__init__.py
+++ b/src/ethiack_job_manager/__init__.py
@@ -1,4 +1,31 @@
-"""Ethiack Job Manager"""
+# -*- coding: utf-8 -*-
+"""Ethiack Job Manager - Client for Ethiack's Public API
+
+This package provides a Python client for interacting with Ethiack's Public API
+to manage security scanning jobs. It includes functionality to check URL validity,
+launch security scans, monitor job status, retrieve results, and more.
+
+The package requires authentication through API credentials, which can be set via
+environment variables (ETHIACK_API_KEY and ETHIACK_API_SECRET) or a .env file.
+
+Modules:
+    cli: Command-line interface for the job manager
+    manager: Core functions for interacting with the Ethiack API
+    types: Type definitions and Pydantic models for job-related data
+    utils: Utility functions, enums, and helpers
+
+Basic Usage:
+    from ethiack_job_manager import manager
+
+    # Check if a URL is valid for scanning
+    response = manager.check("https://example.com")
+
+    # Launch a security scan
+    job = manager.launch_job("https://example.com")
+
+    # Wait for a job to complete and get results
+    success = manager.wait_for_job(job.uuid)
+"""
 
 from __future__ import annotations
 

--- a/src/ethiack_job_manager/manager.py
+++ b/src/ethiack_job_manager/manager.py
@@ -1,15 +1,40 @@
-import json
+# -*- coding: utf-8 -*-
+"""Core API client functions for Ethiack Job Manager
+
+This module provides the core functions for interacting with Ethiack's Public API
+to manage security scanning jobs. It includes functions to check URL validity,
+launch jobs, cancel jobs, get job information, monitor status, and determine
+job success.
+
+Each function corresponds to a specific API endpoint and returns a Pydantic model
+representing the API response. The module handles authentication, request formatting,
+error handling, and response parsing.
+
+Functions:
+    check: Verify if a URL is valid for security scanning
+    launch_job: Launch a new security scan job
+    cancel_job: Cancel a running or queued job
+    get_job_info: Get detailed information about a specific job
+    get_jobs_list: List all jobs
+    get_job_status: Check the current status of a job
+    get_job_success: Determine if a job completed successfully
+    wait_for_job: Wait for a job to finish with exponential backoff
+
+The module uses the requests library for HTTP communication and tenacity
+for implementing retry logic when waiting for jobs to complete.
+"""
+
 import typing
 import urllib.parse
 
 import pydantic
 import requests
-import rich_click as click
 import tenacity
 
-from ethiack_job_manager import (api_auth, ETHIACK_API_URL,
-                                 ETHIACK_API_VER, CONNECT_TIMEOUT, READ_TIMEOUT,
-                                 types, utils)
+from ethiack_job_manager import (api_auth, CONNECT_TIMEOUT, ETHIACK_API_URL,
+                                 ETHIACK_API_VER, READ_TIMEOUT, types, utils)
+from ethiack_job_manager.utils import process_response
+
 
 __all__ = ["check", "launch_job", "cancel_job", "get_job_info", "get_jobs_list",
            "get_job_status", "get_job_success",
@@ -17,95 +42,30 @@ __all__ = ["check", "launch_job", "cancel_job", "get_job_info", "get_jobs_list",
            "JobStatusResponse", "JobSuccessQuery", "JobSuccessResponse",
            "LaunchJobResponse", "ListJobsResponse"]
 
+
+
 T = typing.TypeVar("T", bound=pydantic.BaseModel)
-
-
-def handle_http_error(err: requests.HTTPError, echo: bool, fail: bool) -> None:
-    """Handle HTTP errors.
-
-    This function will handle HTTP errors and print the error message to the
-    user. If the error is raised in a click context, it will exit the program
-    with exit code 1. Otherwise, it will re-raise the exception.
-
-    Args:
-        err (HTTPError): The HTTP error to be handled.
-        echo (bool, optional): Echo the response using click.
-        fail (bool, optional): Exit the program with nonzero code if the check
-            fails.
-    Raises:
-        requests.HTTPError: Re-raises the HTTP error if not in click context.
-    """
-    err_msg = str(err)
-
-    if "application/json" in err.response.headers.get("content-type", ""):
-        json_response = err.response.json()
-        if "error" in json_response:
-            additional_info = f"(Error) {json_response['error']}"
-        elif "validation_error" in json_response:
-            additional_info = (f"(Validation Error) "
-                               f"{json_response['validation_error']}")
-        else:
-            additional_info = f"(Unknown error) {json_response}"
-
-        err_msg = f"{err_msg}\n - Additional info: {additional_info}"
-
-    ctx = click.get_current_context(silent=True)
-    if ctx is not None and ctx.command is not None:
-        exit_code = 1 if fail else 0
-        if echo:
-            exc = click.ClickException(err_msg)
-            exc.exit_code = exit_code
-            raise exc
-        else:
-            ctx.exit(exit_code)
-    else:
-        raise requests.exceptions.HTTPError(err_msg, response=err.response)
-
-
-def process_response(response: requests.Response,
-                     model: typing.Type[T],
-                     echo: bool = False,
-                     fail: bool = True) -> T:
-    """Process a response from the API.
-
-    Args:
-        response (requests.Response): Response from the API.
-        model (T, optional): Pydantic model to validate the response.
-        echo (bool, optional): Echo the response using click. Defaults to False.
-        fail (bool, optional): Exit the program with nonzero code if the
-            response status code is not 2xx or 3xx. Defaults to True.
-    Returns:
-        T: Validated response object.
-    Raises:
-        requests.HTTPError: If the response status code is not 2xx or 3xx.
-    """
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as err:
-        handle_http_error(err, echo=echo, fail=fail)
-    response_obj = model.model_validate(response.json())
-    if echo:
-        click.echo(response_obj.model_dump_json(indent=2))
-    return response_obj
 
 
 class CheckResponse(pydantic.BaseModel):
     """Response object for job validity"""
 
-    url: str
-    """URL of the service"""
-
-    valid: bool
-    """Whether the job can be submitted"""
+    url: str = pydantic.Field(description="URL of the service")
+    valid: bool = pydantic.Field(description="Whether the job is valid")
 
 
-def check(url: str | types.Url,
+def check(url: str | pydantic.AnyUrl,
+          *,
+          beacon_id: int | None = None,
+          event_slug: str | None = None,
           echo: bool = False,
           fail: bool = True) -> CheckResponse:
     """Check if a URL is valid and a job can be submitted.
 
     Args:
-        url (str | types.Url): URL of the service.
+        url (str | pydantic.AnyUrl): URL of the service.
+        beacon_id (int | None): Beacon ID of the service. Defaults to None.
+        event_slug (str | None): Event slug of the service. Defaults to None.
         echo (bool, optional): Echo the response using click. Defaults to False.
         fail (bool, optional): Exit the program with nonzero code if the check
         fails. Defaults to True.
@@ -115,14 +75,15 @@ def check(url: str | types.Url,
         requests.HTTPError: If the response status code is not 2xx or 3xx.
     """
 
-    service = types.Service.model_validate(dict(url=url))
+    service = types.Service.model_validate(dict(url=url, beacon_id=beacon_id,
+                                                event_slug=event_slug))
     req_url = urllib.parse.urljoin(ETHIACK_API_URL,
                                    f"{ETHIACK_API_VER}/jobs/check")
     response = requests.post(req_url,
                              auth=api_auth(),
                              headers={"Content-type": "application/json",
                                       "Accept": "application/json"},
-                             data=json.dumps({"url": service.url}),
+                             data=service.model_dump_json(),
                              timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
     return process_response(response, model=CheckResponse, echo=echo,
                             fail=fail)
@@ -131,14 +92,18 @@ def check(url: str | types.Url,
 class LaunchJobResponse(pydantic.BaseModel):
     """Response from the launch job endpoint."""
 
-    url: str
-    """URL of the service"""
+    url: str = pydantic.Field(description="URL of the service")
+    uuid: str = pydantic.Field(description="UUID of the job")
+    success: bool = pydantic.Field(
+        default=True,
+        description="Whether the job was successfully launched."
+    )
 
-    uuid: str
-    """UUID of the job"""
 
-
-def launch_job(url: str | types.Url,
+def launch_job(url: str | pydantic.AnyUrl,
+               *,
+               beacon_id: int | None = None,
+               event_slug: str | None = None,
                echo: bool = False,
                wait: bool = False,
                timeout: int = 3600,
@@ -146,9 +111,11 @@ def launch_job(url: str | types.Url,
                fail: bool = True
                ) -> LaunchJobResponse:
     """Launch a job.
-
+    
     Args:
         url (pydantic.AnyUrl): URL of the service.
+        beacon_id (int | None): Beacon ID of the service. Defaults to None.
+        event_slug (str | None): Event slug of the service. Defaults to None.
         echo (bool, optional): Echo the response using click. Defaults to False.
         wait (bool, optional): Wait for the job to finish. Defaults to False.
         timeout (int, optional): Maximum time to wait for the job to finish in
@@ -163,14 +130,15 @@ def launch_job(url: str | types.Url,
         requests.HTTPError: If the response status code is not 2xx or 3xx.
     """
 
-    service = types.Service.model_validate(dict(url=url))
+    service = types.Service.model_validate(dict(url=url, beacon_id=beacon_id,
+                                                event_slug=event_slug))
     req_url = urllib.parse.urljoin(ETHIACK_API_URL,
                                    f"{ETHIACK_API_VER}/jobs/launch")
     response = requests.post(req_url,
                              auth=api_auth(),
                              headers={"Content-type": "application/json",
                                       "Accept": "application/json"},
-                             data=json.dumps({"url": service.url}),
+                             data=service.model_dump_json(),
                              timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
 
     launch_info = process_response(response, model=LaunchJobResponse, echo=echo)
@@ -186,17 +154,20 @@ def launch_job(url: str | types.Url,
 class CancelJobResponse(pydantic.BaseModel):
     """Response from the cancel job endpoint."""
 
-    success: bool
-    """Whether the job was successfully cancelled."""
+    success: bool = pydantic.Field(
+        description="Whether the job was successfully cancelled."
+    )
 
-    message: str = pydantic.Field(alias="description")
-    """Message from the API."""
+    message: str = pydantic.Field(
+        alias="description",
+        description="Message from the API"
+    )
 
     class Config:
         populate_by_name = True
 
 
-def cancel_job(uuid: str, echo: bool = False) -> CancelJobResponse:
+def cancel_job(uuid: str, *, echo: bool = False) -> CancelJobResponse:
     """Cancel a queued or running job.
 
     Args:
@@ -218,11 +189,10 @@ def cancel_job(uuid: str, echo: bool = False) -> CancelJobResponse:
 class JobInfoResponse(pydantic.BaseModel):
     """Response from the job info endpoint."""
 
-    job: types.JobFindings
-    """Job information."""
+    job: types.JobFindings = pydantic.Field(description="Job information")
 
 
-def get_job_info(uuid: str, echo: bool = False) -> JobInfoResponse:
+def get_job_info(uuid: str, *, echo: bool = False) -> JobInfoResponse:
     """Get information about a job.
 
     Args:
@@ -244,11 +214,10 @@ def get_job_info(uuid: str, echo: bool = False) -> JobInfoResponse:
 class ListJobsResponse(pydantic.BaseModel):
     """Response from the list jobs endpoint."""
 
-    jobs: list[types.Job]
-    """List of jobs."""
+    jobs: list[types.Job] = pydantic.Field(description="List of jobs")
 
 
-def get_jobs_list(echo: bool = False) -> ListJobsResponse:
+def get_jobs_list(*, echo: bool = False) -> ListJobsResponse:
     """List all jobs.
 
     Args:
@@ -267,10 +236,10 @@ def get_jobs_list(echo: bool = False) -> ListJobsResponse:
 
 
 class JobStatusResponse(pydantic.BaseModel):
-    status: str
+    status: str = pydantic.Field(description="Status of the job")
 
 
-def get_job_status(uuid: str, echo: bool = False) -> JobStatusResponse:
+def get_job_status(uuid: str, *, echo: bool = False) -> JobStatusResponse:
     """Show the status of a job.
 
     Args:
@@ -293,21 +262,29 @@ def get_job_status(uuid: str, echo: bool = False) -> JobStatusResponse:
 class JobSuccessQuery(pydantic.BaseModel):
     """Query parameters for the job success endpoint."""
 
-    severity: utils.Severity
-    """Minimum severity level that should fail."""
+    severity: utils.Severity = pydantic.Field(
+        description="Minimum severity level that should fail."
+    )
 
-    fail: bool = True
-    """Exit with nonzero code if the job was unsuccessful."""
+    fail: bool = pydantic.Field(
+        default=True,
+        description="Exit with nonzero code if the job was unsuccessful."
+    )
 
 
 class JobSuccessResponse(pydantic.BaseModel):
     """Response from the job success endpoint."""
 
-    success: bool | None = None
-    """Whether the job was successful."""
+    success: bool | None = pydantic.Field(
+        default=None,
+        description="Whether the job was successful."
+    )
 
-    message: str | None = pydantic.Field(default=None, alias="description")
-    """Message from the API."""
+    message: str | None = pydantic.Field(
+        default=None,
+        alias="description",
+        description="Message from the API."
+    )
 
     class Config:
         populate_by_name = True
@@ -315,6 +292,7 @@ class JobSuccessResponse(pydantic.BaseModel):
 
 def get_job_success(uuid: str,
                     severity: str,
+                    *,
                     echo: bool = False,
                     fail: bool = True) -> JobSuccessResponse:
     """Retrieve the success of a job.
@@ -345,6 +323,7 @@ def get_job_success(uuid: str,
 
 
 def wait_for_job(uuid: str,
+                 *,
                  severity: str = utils.Severity.MEDIUM.value,
                  timeout: int = 3600,
                  echo: bool = False,

--- a/src/ethiack_job_manager/types.py
+++ b/src/ethiack_job_manager/types.py
@@ -1,7 +1,24 @@
-"""Types for the Ethiack Job Manager."""
+# -*- coding: utf-8 -*-
+"""Type definitions and Pydantic models for Ethiack Job Manager
+
+This module defines the Pydantic models that represent the data structures used
+in the Ethiack Job Manager. These models are used for validating input data,
+serializing requests to the API, and parsing responses from the API.
+
+Classes:
+    Service: Represents a target service for security scanning
+    Finding: Represents a security finding/vulnerability identified in a scan
+    Job: Represents metadata about a security scan job
+    JobFindings: Extends Job with detailed findings information
+
+Type Annotations:
+    Url: A specialized AnyUrl type that strips trailing slashes
+
+The models use Pydantic for validation, serialization, and deserialization,
+ensuring type safety and consistent data handling throughout the application.
+"""
 
 import datetime
-from typing import Annotated
 
 import pydantic
 
@@ -11,51 +28,73 @@ from ethiack_job_manager import utils
 __all__ = ["Service", "Finding", "Job", "JobFindings"]
 
 
-Url = Annotated[pydantic.AnyUrl,
-                pydantic.AfterValidator(lambda x: str(x).rstrip('/'))]
-
-
 class Service(pydantic.BaseModel):
     """Service model"""
 
-    url: Url
-    """URL of the service"""
+    url: pydantic.AnyUrl = pydantic.Field(
+        description="URL of the service"
+    )
+
+    beacon_id: int | None = pydantic.Field(
+        default=None,
+        description="Beacon ID of the service"
+    )
+
+    event_slug: str | None = pydantic.Field(
+        default=None,
+        description="Event slug of the service"
+    )
+
+    @pydantic.field_serializer("url")
+    def serialize_url(self, value: pydantic.AnyUrl) -> str:
+        """Serialize URL to string without trailing slash"""
+        return str(value).rstrip('/')
 
 
 class Finding(pydantic.BaseModel):
     """Finding model"""
 
-    title: str
-    """Title of the finding"""
+    title: str = pydantic.Field(
+        description="Title of the finding"
+    )
 
-    severity: utils.Severity
-    """Severity of the finding"""
-
+    severity: utils.Severity = pydantic.Field(
+        description="Severity of the finding"
+    )
 
 class Job(pydantic.BaseModel):
     """Job model"""
 
-    uuid: str
-    """UUID of the job"""
+    uuid: str = pydantic.Field(
+        description="UUID of the job"
+    )
 
-    url: str
-    """URL of the target service"""
+    url: pydantic.AnyUrl = pydantic.Field(
+        description="URL of the target service"
+    )
 
-    status: str
-    """Status of the job"""
+    status: str = pydantic.Field(
+        description="Status of the job"
+    )
 
-    created: datetime.datetime
-    """Timestamp of the job creation"""
+    created: datetime.datetime = pydantic.Field(
+        description="Timestamp of the job creation"
+    )
 
-    started: datetime.datetime | None = None
-    """Timestamp of the job start"""
+    started: datetime.datetime | None = pydantic.Field(
+        default=None,
+        description="Timestamp of the job start"
+    )
 
-    finished: datetime.datetime | None = None
-    """Timestamp of the job finish"""
+    finished: datetime.datetime | None = pydantic.Field(
+        default=None,
+        description="Timestamp of the job finish"
+    )
 
 
 class JobFindings(Job):
     """JobFindings model"""
 
-    findings: list[Finding]
-    """Findings of the job"""
+    findings: list[Finding] = pydantic.Field(
+        description="Findings of the job"
+    )

--- a/src/ethiack_job_manager/utils.py
+++ b/src/ethiack_job_manager/utils.py
@@ -1,6 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Utility functions and enums for Ethiack Job Manager
+
+This module provides utility functions and enum classes used throughout the
+Ethiack Job Manager package. It includes enums for job status and severity levels,
+as well as helper functions for handling HTTP errors and processing API responses.
+
+Classes:
+    JobStatus: Enum representing possible states of a security scan job
+    Severity: Enum representing severity levels for security findings
+
+Functions:
+    handle_http_error: Process HTTP errors from the API and provide user-friendly messages
+    process_response: Process API responses, validate with Pydantic models, and handle errors
+
+These utilities provide consistent error handling, response processing,
+and data validation across the package.
+"""
+
 import enum
+import typing
+
+import pydantic
+import requests
+import rich_click as click
+
 
 __all__ = ["JobStatus", "Severity"]
+
+
+T = typing.TypeVar("T", bound=pydantic.BaseModel)
 
 
 class JobStatus(str, enum.Enum):
@@ -21,3 +49,72 @@ class Severity(str, enum.Enum):
     LOW = "low"
     INFO = "info"
     NONE = "none"
+
+
+def handle_http_error(err: requests.HTTPError, echo: bool, fail: bool) -> None:
+    """Handle HTTP errors.
+
+    This function will handle HTTP errors and print the error message to the
+    user. If the error is raised in a click context, it will exit the program
+    with exit code 1. Otherwise, it will re-raise the exception.
+
+    Args:
+        err (HTTPError): The HTTP error to be handled.
+        echo (bool, optional): Echo the response using click.
+        fail (bool, optional): Exit the program with nonzero code if the check
+            fails.
+    Raises:
+        requests.HTTPError: Re-raises the HTTP error if not in click context.
+    """
+    err_msg = str(err)
+
+    if "application/json" in err.response.headers.get("content-type", ""):
+        json_response = err.response.json()
+        if "error" in json_response:
+            additional_info = f"(Error) {json_response['error']}"
+        elif "validation_error" in json_response:
+            additional_info = (f"(Validation Error) "
+                               f"{json_response['validation_error']}")
+        else:
+            additional_info = f"(Unknown error) {json_response}"
+
+        err_msg = f"{err_msg}\n\nAdditional info: {additional_info}\n"
+
+    ctx = click.get_current_context(silent=True)
+    if ctx is not None and ctx.command is not None:
+        exit_code = 1 if fail else 0
+        if echo:
+            exc = click.ClickException(err_msg)
+            exc.exit_code = exit_code
+            raise exc
+        else:
+            ctx.exit(exit_code)
+    else:
+        raise requests.exceptions.HTTPError(err_msg, response=err.response)
+
+
+def process_response(response: requests.Response,
+                     model: typing.Type[T],
+                     echo: bool = False,
+                     fail: bool = True) -> T:
+    """Process a response from the API.
+
+    Args:
+        response (requests.Response): Response from the API.
+        model (T, optional): Pydantic model to validate the response.
+        echo (bool, optional): Echo the response using click. Defaults to False.
+        fail (bool, optional): Exit the program with nonzero code if the
+            response status code is not 2xx or 3xx. Defaults to True.
+    Returns:
+        T: Validated response object.
+    Raises:
+        requests.HTTPError: If the response status code is not 2xx or 3xx.
+    """
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as err:
+        handle_http_error(err, echo=echo, fail=fail)
+    response_obj = model.model_validate(response.json())
+    if echo:
+        click.echo(response_obj.model_dump_json(indent=2))
+    return response_obj


### PR DESCRIPTION
This pull request includes several changes to enhance the Ethiack Job Manager's functionality, add new features, and improve documentation. The most important changes include the addition of Multi-Event and Beacon logic, updates to the CLI to support new options, and comprehensive module-level docstrings for better clarity.

### New Features:
* Added Multi-Event and Beacon logic to the project.

### CLI Enhancements:
* Updated CLI commands to include `--beacon-id` and `--event-slug` options for `check` and `launch` commands. [[1]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dR78-R89) [[2]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dL57-R103) [[3]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dR112-R115) [[4]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dL81-R133) [[5]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dR149-R150)

### Documentation Improvements:
* Added comprehensive module-level docstrings to `src/ethiack_job_manager/__init__.py`, `src/ethiack_job_manager/cli.py`, and `src/ethiack_job_manager/manager.py` for better clarity and understanding of the package's functionality. [[1]](diffhunk://#diff-688084537aa9e024f79eaf10911ee0f1b8de1d1a437075380a21328d616d6a41L1-R28) [[2]](diffhunk://#diff-30b679fef0e1914a722389e8e51bb704ddc5675382613389fe1affbbff632c1dL1-R41) [[3]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L1-R68)

### Version Update:
* Updated the version in `pyproject.toml` from `1.0.2` to `1.1.0rc1` to reflect the new release candidate.

### Code Refactoring:
* Refactored `manager.py` to use `pydantic.Field` for better field descriptions and added new parameters to the `check` and `launch_job` functions to support the new features. [[1]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L1-R68) [[2]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L118-R86) [[3]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L134-R106) [[4]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102R117-R118) [[5]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L166-R141) [[6]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L189-R170) [[7]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L221-R195) [[8]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L247-R220) [[9]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L270-R242) [[10]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102L296-R295) [[11]](diffhunk://#diff-08797a7e100ad53a6ed2cd78b35c15311fb842731781abf8c78c16ff9c776102R326)